### PR TITLE
fix overflow of shift expression 2 << 31

### DIFF
--- a/include/TBRecHit.h
+++ b/include/TBRecHit.h
@@ -33,7 +33,7 @@ class TBRecHit : public TObject {
     kZSP=128,           ///< signal is below ZSP threshold
     kMonitor=256,       ///< monitor for laser pulse, no calorimeter connection
     kCalibrated=512,    ///< set if calibration applied
-    kUnknown=2<<31      ///< set for weirdness
+    kUnknown=2<<29      ///< set for weirdness
   };
   /// Constructor
   TBRecHit(PadeChannel *pc=0, Float_t zsp=0, UInt_t options=0);


### PR DESCRIPTION
Compiler gives an error:
`
In file included from /home/sasha/WorkPlace/CMS/Upgrade/TB2016/H4TestBeam/test/AddHodoInfo.cpp:24:0:
./include/TBRecHit.h:36:15: warning: result of ‘(2 << 31)’ requires 34 bits to represent, but ‘int’ only has 32 bits [-Wshift-overflow=]
     kUnknown=2<<31      ///< set for weirdness
              ~^~~~
./include/TBRecHit.h:36:15: error: shift expression ‘(2 << 31)’ overflows [-fpermissive]
./include/TBRecHit.h:36:17: error: enumerator value for ‘kUnknown’ is not an integer constant
     kUnknown=2<<31      ///< set for weirdness
                 ^~

`
